### PR TITLE
[HOTFIX] fix sls deploy problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "serverless-offline": "^3.16.0"
   },
   "dependencies": {
+    "aws-sdk": "^2.175.0",
     "crypto-js": "^3.1.9-1",
     "multi-hash": "^0.1.1",
     "serverless-kms-secrets": "^1.0.2",
     "serverless-webpack": "^3.1.0",
     "uport": "0.6.0",
+    "uport-lite": "^1.0.2",
     "webpack": "^3.6.0",
     "webpack-node-externals": "^1.6.0"
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,32 +40,6 @@ functions:
          path: v1/event
          method: post
 
-  event_get_all:
-    handler: src/api-v1_handler.event_get
-    description: Gets all of the events with a limit of 100
-    events:
-     - http:
-         path: v1/event
-         method: get
-         request:
-           parameters:
-             paths:
-               page: false
-               per_page: false
-
-  event_get_paginated:
-    handler: src/api-v1_handler.event_get
-    description: Gets a paginated subset of the events of the user.
-    events:
-     - http:
-         path: v1/event/{page}/{per_page}
-         method: get
-         request:
-           parameters:
-             paths:
-               page: true
-               per_page: true
-
   event_get:
     handler: src/api-v1_handler.event_get
     description: Retrieve a particular event
@@ -77,3 +51,28 @@ functions:
             parameters:
               paths:
                 id: true
+
+  event_get_all:
+    handler: src/api-v1_handler.event_get
+    description: Gets all of the events with a limit of 100
+    events:
+     - http:
+         path: v1/event
+         method: get
+
+
+  event_get_paginated:
+    handler: src/api-v1_handler.event_get
+    description: Gets a paginated subset of the events of the user.
+    events:
+     - http:
+         path: v1/event
+         method: get
+         integration: lambda
+         request:
+           template:
+             application/json: >
+               {
+                 "page" : "$input.params(''page'')",
+                 "per_page": "$input.params(''per_page'')"
+               }

--- a/src/api-v1/__tests__/event_get.test.js
+++ b/src/api-v1/__tests__/event_get.test.js
@@ -108,7 +108,8 @@ describe('EventGetHandler', () => {
       })
       sut.handle({
         headers: { Authorization: 'Bearer '+validToken },
-        pathParameters: {page: 2, per_page: 2}
+        page: 2,
+        per_page: 2
       }, {}, (err, res) => {
         expect(err).toBeNull()
         expect(res.total).toEqual(6)

--- a/src/api-v1/event_get.js
+++ b/src/api-v1/event_get.js
@@ -66,9 +66,9 @@ class V1EventGetHandler {
 
             let params = event.pathParameters
 
-            if (params && params.page && params.per_page){
-              page = params.page
-              perPage = params.per_page
+            if (event.page && event.per_page){
+              page = event.page
+              perPage = event.per_page
             } else {
               //provide defaults
               page = 1


### PR DESCRIPTION
Changes added: 
- Add fixed versions to npm packages bundled by serverless (it caused problems in the past, specially with `lambda-onfido` and `lambda-sensui`)
- Change request template for paginated requests. This way the parameters are options on the querystring, `GET /v1/event?page=1&per_page=50`